### PR TITLE
Add sensible defaults/updates for a simplified speedrun

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,16 +1,28 @@
-app = "ollama-demo"
+app = "" # Change this to your app name
 primary_region = "ord"
-vm.size = "a100-40gb"
 
 [build]
-image = "ollama/ollama:latest"
+  image = "ollama/ollama:latest"
 
 [[mounts]]
-source = "ollama"
-destination = "/root/.ollama"
+  source = "ollama"
+  destination = "/root/.ollama"
+  initial_size = "10gb"
 
 [http_service]
-internal_port = 11434
-auto_stop_machines = true
-auto_start_machines = true
-min_machines_running = 0
+  internal_port = 11434
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[http_service.checks]]
+  grace_period = "10s"
+  interval = "30s"
+  method = "GET"
+  timeout = "5s"
+  path = "/"
+
+[[vm]]
+  size = "performance-8x"
+  memory = "16gb"
+  gpu_kind = "l40s"


### PR DESCRIPTION
Mainly adds an initial volume size of 10g as well as updates vm block—prefer l40s in-line with GPU speedrun: https://fly.io/gpu